### PR TITLE
Add meeting reminders to notifications panel

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -15,6 +15,7 @@ import SystemOperationsView from './views/SystemOperationsView';
 import ConfirmationModal from './components/ConfirmationModal';
 import { useSimulation } from './hooks/useSimulation';
 import VoiceAgentView from './views/VoiceAgentView';
+import NotificationPanel from './components/NotificationPanel';
 
 const App: React.FC = () => {
   const { 
@@ -63,6 +64,9 @@ const App: React.FC = () => {
       <main className="flex-1 p-6 overflow-y-auto">
         {renderView()}
       </main>
+      <div className="fixed top-4 right-4 w-96 space-y-4">
+        <NotificationPanel />
+      </div>
       {confirmation.isActive && (
         <ConfirmationModal
           message={confirmation.message}

--- a/components/NotificationPanel.tsx
+++ b/components/NotificationPanel.tsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useState } from 'react';
+import { useNotificationStore } from '../store/notificationStore';
+import { Card, CardContent, CardHeader, CardTitle } from './ui/Card';
+import { Input } from './ui/Input';
+import { Button } from './ui/Button';
+
+const NotificationPanel: React.FC = () => {
+  const {
+    notifications,
+    removeNotification,
+    reminders,
+    addReminder,
+    removeReminder,
+    pushNotification,
+  } = useNotificationStore();
+
+  const [title, setTitle] = useState('');
+  const [time, setTime] = useState('');
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const now = new Date();
+      reminders.forEach(rem => {
+        if (new Date(rem.time) <= now) {
+          pushNotification('info', `Meeting reminder: ${rem.title}`);
+          removeReminder(rem.id);
+        }
+      });
+    }, 60000);
+    return () => clearInterval(interval);
+  }, [reminders, pushNotification, removeReminder]);
+
+  const handleAddReminder = () => {
+    if (title && time) {
+      addReminder(title, time);
+      setTitle('');
+      setTime('');
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Meeting Reminders</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <div className="flex space-x-2">
+            <Input
+              placeholder="Meeting title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+            <Input
+              type="datetime-local"
+              value={time}
+              onChange={(e) => setTime(e.target.value)}
+            />
+            <Button onClick={handleAddReminder}>Add</Button>
+          </div>
+          {reminders.length > 0 && (
+            <ul className="space-y-1">
+              {reminders.map(rem => (
+                <li key={rem.id} className="flex justify-between">
+                  <span>
+                    {rem.title} - {new Date(rem.time).toLocaleString()}
+                  </span>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => removeReminder(rem.id)}
+                  >
+                    Remove
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Notifications</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {notifications.length === 0 ? (
+            <p>No notifications</p>
+          ) : (
+            <ul className="space-y-1">
+              {notifications.map(n => (
+                <li key={n.id} className="flex justify-between">
+                  <span>{n.message}</span>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => removeNotification(n.id)}
+                  >
+                    Dismiss
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default NotificationPanel;

--- a/store/agentStore.ts
+++ b/store/agentStore.ts
@@ -222,7 +222,18 @@ export const useAgentStore = create<AgentState>((set, get) => ({
     }]
   })),
   editAgent: (agentName, updates) => set(state => ({
-    agents: state.agents.map(a => a.name === agentName ? { ...a, ...updates } : a)
+    agents: state.agents.map(a => {
+      if (a.name !== agentName) return a;
+
+      const { modelFile, ...rest } = updates;
+      return {
+        ...a,
+        ...rest,
+        ...(modelFile !== undefined
+          ? { modelFile: typeof modelFile === 'string' ? modelFile : modelFile?.name }
+          : {}),
+      };
+    }),
   })),
   deleteAgent: (agentName) => set(state => ({
     agents: state.agents.filter(a => a.name !== agentName)
@@ -574,6 +585,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
                 isRecording: true,
                 voiceChatHistory: [initialMessage],
                 automaticNotes: [],
+                agenda: state.voiceAgentState.agenda,
             }
         };
     }

--- a/store/notificationStore.ts
+++ b/store/notificationStore.ts
@@ -7,14 +7,24 @@ export interface Notification {
   timestamp: string;
 }
 
+export interface MeetingReminder {
+  id: string;
+  title: string;
+  time: string; // ISO string
+}
+
 interface NotificationState {
   notifications: Notification[];
+  reminders: MeetingReminder[];
   pushNotification: (type: Notification['type'], message: string) => void;
   removeNotification: (id: string) => void;
+  addReminder: (title: string, time: string) => void;
+  removeReminder: (id: string) => void;
 }
 
 export const useNotificationStore = create<NotificationState>((set) => ({
   notifications: [],
+  reminders: [],
   pushNotification: (type, message) => set((state) => ({
     notifications: [
       ...state.notifications,
@@ -28,5 +38,14 @@ export const useNotificationStore = create<NotificationState>((set) => ({
   })),
   removeNotification: (id) => set((state) => ({
     notifications: state.notifications.filter(n => n.id !== id),
+  })),
+  addReminder: (title, time) => set((state) => ({
+    reminders: [
+      ...state.reminders,
+      { id: `rem-${Date.now()}`, title, time },
+    ],
+  })),
+  removeReminder: (id) => set((state) => ({
+    reminders: state.reminders.filter(r => r.id !== id),
   })),
 }));


### PR DESCRIPTION
## Summary
- extend notification store with meeting reminders
- implement NotificationPanel with reminder scheduling and notification display
- show notification panel across the app
- ensure agent edits store model file names instead of File objects
- include agenda data when starting voice recordings to satisfy typing

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bba651b7848320ac39c742c5ef3d1b